### PR TITLE
Fixing missing cascade delete.

### DIFF
--- a/backend/migrations/2024-12-17-120244_initial_setup/up.sql
+++ b/backend/migrations/2024-12-17-120244_initial_setup/up.sql
@@ -3,7 +3,7 @@ CREATE TABLE user (
     uuid TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
     avatar TEXT NOT NULL,
-    dm INTEGER NOT NULL NOT NULL,
+    dm INTEGER NOT NULL,
     creation TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -14,7 +14,7 @@ CREATE TABLE item_preset (
     weight REAL NOT NULL,
     description TEXT NOT NULL,
     creator TEXT NOT NULL,
-    item_type TEXT NOT NULL NOT NULL,
+    item_type TEXT NOT NULL,
     creation TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/backend/src/dbmod.rs
+++ b/backend/src/dbmod.rs
@@ -2,11 +2,25 @@
 use diesel::r2d2::{self, ConnectionManager};
 use diesel::sqlite::SqliteConnection;
 use std::env;
+use diesel::RunQueryDsl;
+
+
+#[derive(Debug)]
+pub struct SqliteConnectionCustomizer;
+
+impl r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for SqliteConnectionCustomizer {
+    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+        diesel::sql_query("PRAGMA foreign_keys = ON;")
+        .execute(conn)
+        .expect("Failed to enable foreign key constraints");
+        Ok(())
+    }
+}
 
 pub type DbPool = r2d2::Pool<ConnectionManager<SqliteConnection>>;
 
 pub fn establish_connection() -> DbPool {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let manager = ConnectionManager::<SqliteConnection>::new(database_url);
-    r2d2::Pool::builder().build(manager).expect("Failed to create pool.")
+    r2d2::Pool::builder().connection_customizer(Box::new(SqliteConnectionCustomizer)).build(manager).expect("Failed to create pool.")
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -35,11 +35,6 @@ async fn main() {
         .execute(&mut conn)
         .expect("Failed to set journal mode");
 
-        // Aktiviere Foreign Key Constraints
-    diesel::sql_query("PRAGMA foreign_keys = ON;")
-        .execute(&mut conn)
-        .expect("Failed to enable foreign key constraints");
-
     let inv_cont = InventoryController::new(dbconn.clone());
     let acc_con = AccountController::new(dbconn.clone());
     let ip_con = ItemPresetController::new(dbconn.clone());


### PR DESCRIPTION
Sqlite requires enabling the foreign key support for each connection. This is now done with the connection customizer. Closes #54 